### PR TITLE
Updates for Bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ opt-level = 1
 opt-level = 3
 
 [dev-dependencies]
-bevy = { version = "0.12", default-features = false, features = [
+bevy = { version = "0.13", default-features = false, features = [
     "multi-threaded",
     "bevy_asset",
     "bevy_winit",
@@ -66,8 +66,6 @@ required-features = ["dev"]
 path = "./examples/simple.rs"
 
 [dependencies]
-bevy = { version = "0.12", default-features = false }
-bevy_tweening = "0.9"
+bevy = { version = "0.13", default-features = false }
+bevy_tweening = "0.10"
 
-[patch.crates-io]
-bevy_tweening = { git = "https://github.com/SergioRibera/bevy_tweening", branch = "infinite_mirrored" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,5 @@ path = "./examples/simple.rs"
 bevy = { version = "0.13", default-features = false }
 bevy_tweening = "0.10"
 
+[patch.crates-io]
+bevy_tweening = { git = "https://github.com/SergioRibera/bevy_tweening", branch = "infinite_mirrored" }

--- a/examples/custom_skip.rs
+++ b/examples/custom_skip.rs
@@ -17,7 +17,7 @@ enum ScreenStates {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_state::<ScreenStates>()
+        .init_state::<ScreenStates>()
         .add_plugins(
             SplashPlugin::new(ScreenStates::Splash, ScreenStates::Menu)
                 .ignore_default_events()
@@ -41,7 +41,7 @@ fn main() {
                                     },
                                 ),
                             ])
-                            .with_alignment(TextAlignment::Center),
+                            .with_justify(JustifyText::Center),
                             "FiraSans-Bold.ttf".to_string(),
                         ),
                         tint: Color::WHITE,
@@ -64,7 +64,7 @@ fn main() {
                                     ..default()
                                 },
                             )
-                            .with_alignment(TextAlignment::Center),
+                            .with_justify(JustifyText::Center),
                             "FiraSans-Bold.ttf".to_string(),
                         ),
                         tint: Color::WHITE,
@@ -124,7 +124,7 @@ fn create_scene(mut cmd: Commands, assets: ResMut<AssetServer>) {
                             ..default()
                         },
                     )
-                    .with_alignment(TextAlignment::Center),
+                    .with_justify(JustifyText::Center),
                     ..default()
                 },
                 Animator::new(
@@ -147,7 +147,7 @@ fn button_system(
 ) {
     for interaction in &mut interaction_query {
         match *interaction {
-            Interaction::Pressed => send_skip.send(SplashScreenSkipEvent),
+            Interaction::Pressed => {send_skip.send(SplashScreenSkipEvent); },
             _ => {}
         }
     }

--- a/examples/custom_skip.rs
+++ b/examples/custom_skip.rs
@@ -147,7 +147,7 @@ fn button_system(
 ) {
     for interaction in &mut interaction_query {
         match *interaction {
-            Interaction::Pressed => {send_skip.send(SplashScreenSkipEvent); },
+            Interaction::Pressed => send_skip.send(SplashScreenSkipEvent),
             _ => {}
         }
     }

--- a/examples/layouts.rs
+++ b/examples/layouts.rs
@@ -14,7 +14,7 @@ enum ScreenStates {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_state::<ScreenStates>()
+        .init_state::<ScreenStates>()
         .add_plugins(
             SplashPlugin::new(ScreenStates::Splash, ScreenStates::Menu)
                 .skipable()
@@ -48,7 +48,7 @@ fn main() {
                                         },
                                     ),
                                 ])
-                                .with_alignment(TextAlignment::Center),
+                                .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
                             tint: Color::SEA_GREEN,
@@ -68,7 +68,7 @@ fn main() {
                                         ..default()
                                     },
                                 )])
-                                .with_alignment(TextAlignment::Center),
+                                .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
                             tint: Color::WHITE,
@@ -95,7 +95,7 @@ fn main() {
                                         ..default()
                                     },
                                 )])
-                                .with_alignment(TextAlignment::Center),
+                                .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
                             tint: Color::YELLOW,
@@ -115,7 +115,7 @@ fn main() {
                                         ..default()
                                     },
                                 )])
-                                .with_alignment(TextAlignment::Center),
+                                .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
                             tint: Color::BLUE,
@@ -135,7 +135,7 @@ fn main() {
                                         ..default()
                                     },
                                 )])
-                                .with_alignment(TextAlignment::Center),
+                                .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
                             tint: Color::WHITE,
@@ -155,7 +155,7 @@ fn main() {
                                         ..default()
                                     },
                                 )])
-                                .with_alignment(TextAlignment::Center),
+                                .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
                             tint: Color::PURPLE,

--- a/examples/screens.rs
+++ b/examples/screens.rs
@@ -14,7 +14,7 @@ enum ScreenStates {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_state::<ScreenStates>()
+        .init_state::<ScreenStates>()
         .add_plugins(
             SplashPlugin::new(ScreenStates::Splash, ScreenStates::Menu)
                 .add_screen(SplashScreen {
@@ -46,7 +46,7 @@ fn main() {
                                     },
                                 ),
                             ])
-                            .with_alignment(TextAlignment::Center),
+                            .with_justify(JustifyText::Center),
                             "FiraSans-Bold.ttf".to_string(),
                         ),
                         tint: Color::SEA_GREEN,
@@ -70,7 +70,7 @@ fn main() {
                                     ..default()
                                 },
                             )])
-                            .with_alignment(TextAlignment::Center),
+                            .with_justify(JustifyText::Center),
                             "FiraSans-Bold.ttf".to_string(),
                         ),
                         tint: Color::WHITE,
@@ -95,7 +95,7 @@ fn main() {
                                     ..default()
                                 },
                             )])
-                            .with_alignment(TextAlignment::Center),
+                            .with_justify(JustifyText::Center),
                             "FiraSans-Bold.ttf".to_string(),
                         ),
                         tint: Color::RED,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -14,7 +14,7 @@ enum ScreenStates {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_state::<ScreenStates>()
+        .init_state::<ScreenStates>()
         .add_plugins(
             SplashPlugin::new(ScreenStates::Splash, ScreenStates::Menu)
                 .skipable()
@@ -48,7 +48,7 @@ fn main() {
                                         },
                                     ),
                                 ])
-                                .with_alignment(TextAlignment::Center),
+                                .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
                             tint: Color::SEA_GREEN,

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -33,10 +33,9 @@ impl Lens<Text> for SplashTextColorLens {
             .iter_mut()
             .enumerate()
             .for_each(|(i, section)| {
-                let start: Vec4 = self.0[i].with_a(0.).into();
-                let end: Vec4 = self.0[i].into();
-                let value = start.lerp(end, ratio);
-                section.style.color = value.into();
+                use crate::ColorLerper as _;
+                let value = self.0[i].with_a(0.).lerp(&self.0[i], ratio);
+                section.style.color = value;
             });
     }
 }
@@ -49,9 +48,8 @@ impl InstanceLens for SplashImageColorLens {
 
 impl Lens<BackgroundColor> for SplashImageColorLens {
     fn lerp(&mut self, target: &mut BackgroundColor, ratio: f32) {
-        let start: Vec4 = self.start.into();
-        let end: Vec4 = self.end.into();
-        let value = start.lerp(end, ratio);
-        target.0 = value.into();
+        use crate::ColorLerper as _;
+        let value = self.start.lerp(&self.end, ratio);
+        target.0 = value;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,3 +132,21 @@ where
             );
     }
 }
+
+/// Trait to interpolate between two values.
+/// Needed for color.
+#[allow(dead_code)]
+trait ColorLerper {
+    fn lerp(&self, target: &Self, ratio: f32) -> Self;
+}
+
+#[allow(dead_code)]
+impl ColorLerper for Color {
+    fn lerp(&self, target: &Color, ratio: f32) -> Color {
+        let r = self.r().lerp(target.r(), ratio);
+        let g = self.g().lerp(target.g(), ratio);
+        let b = self.b().lerp(target.b(), ratio);
+        let a = self.a().lerp(target.a(), ratio);
+        Color::rgba(r, g, b, a)
+    }
+}

--- a/src/splash.rs
+++ b/src/splash.rs
@@ -98,7 +98,7 @@ pub(crate) fn create_splash(
                                 ..s.style
                             },
                         }))
-                        .with_alignment(text.alignment);
+                        .with_justify(text.justify);
                         cmd.spawn((
                             TextBundle {
                                 text: text.clone(),


### PR DESCRIPTION
I believe this is all you need to update the crate to Bevy 0.13
That said, your patched version of bevy_tweening is a few commits behind, and without it the examples run into runtime problems.