### PR TITLE
Upgraded to bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,13 @@ opt-level = 1
 opt-level = 3
 
 [dev-dependencies]
-bevy = { version = "0.13", default-features = false, features = [
-    "multi-threaded",
+bevy = { version = "0.14.1", default-features = false, features = [
+    "multi_threaded",
     "bevy_asset",
     "bevy_winit",
     "bevy_render",
     "bevy_sprite",
+    "bevy_state",
     "png",
 ] }
 
@@ -35,9 +36,10 @@ dev = [
     "bevy/bevy_core_pipeline",
     "bevy/bevy_render",
     "bevy/bevy_sprite",
+    "bevy/bevy_state",
     "bevy/bevy_text",
     "bevy/bevy_ui",
-    "bevy/multi-threaded",
+    "bevy/multi_threaded",
     "bevy/png",
     "bevy/ktx2",
     "bevy/x11",
@@ -66,8 +68,10 @@ required-features = ["dev"]
 path = "./examples/simple.rs"
 
 [dependencies]
-bevy = { version = "0.13", default-features = false }
-bevy_tweening = "0.10"
+bevy = { version = "0.14.1", default-features = false , features = [
+    "bevy_state",
+] }
+bevy_tweening = "0.11.0"
 
 [patch.crates-io]
 bevy_tweening = { git = "https://github.com/SergioRibera/bevy_tweening", branch = "infinite_mirrored" }

--- a/examples/custom_skip.rs
+++ b/examples/custom_skip.rs
@@ -80,7 +80,7 @@ fn main() {
         )
         .add_systems(Startup, create_scene)
         .add_systems(Update, button_system)
-        .run()
+        .run();
 }
 
 fn create_scene(mut cmd: Commands, assets: ResMut<AssetServer>) {
@@ -110,7 +110,7 @@ fn create_scene(mut cmd: Commands, assets: ResMut<AssetServer>) {
                 align_items: AlignItems::Center,
                 ..default()
             },
-            background_color: BackgroundColor(Color::WHITE.with_a(0.)),
+            background_color: BackgroundColor(Color::WHITE.with_alpha(0.)),
             ..default()
         })
         .with_children(|cmd| {
@@ -146,9 +146,8 @@ fn button_system(
     mut send_skip: EventWriter<SplashScreenSkipEvent>,
 ) {
     for interaction in &mut interaction_query {
-        match *interaction {
-            Interaction::Pressed => send_skip.send(SplashScreenSkipEvent),
-            _ => {}
+        if *interaction == Interaction::Pressed {
+            send_skip.send(SplashScreenSkipEvent);
         }
     }
 }

--- a/examples/layouts.rs
+++ b/examples/layouts.rs
@@ -1,8 +1,8 @@
-use std::time::Duration;
-
+use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashType};
 use bevy_tweening::EaseFunction;
+use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Default, States, Hash, PartialEq, Eq)]
 enum ScreenStates {
@@ -35,7 +35,7 @@ fn main() {
                                         "by\n",
                                         TextStyle {
                                             font_size: 24.,
-                                            color: Color::WHITE.with_a(0.75),
+                                            color: Color::WHITE.with_alpha(0.75),
                                             ..default()
                                         },
                                     ),
@@ -51,7 +51,7 @@ fn main() {
                                 .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
-                            tint: Color::SEA_GREEN,
+                            tint: palettes::css::SEA_GREEN.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
                             ease_function: EaseFunction::QuarticInOut.into(),
@@ -98,7 +98,7 @@ fn main() {
                                 .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
-                            tint: Color::YELLOW,
+                            tint: palettes::basic::YELLOW.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
                             ease_function: EaseFunction::QuarticInOut.into(),
@@ -118,7 +118,7 @@ fn main() {
                                 .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
-                            tint: Color::BLUE,
+                            tint: Srgba::BLUE.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
                             ease_function: EaseFunction::QuarticInOut.into(),
@@ -158,7 +158,7 @@ fn main() {
                                 .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
-                            tint: Color::PURPLE,
+                            tint: palettes::basic::PURPLE.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
                             ease_function: EaseFunction::QuarticInOut.into(),
@@ -173,7 +173,7 @@ fn main() {
                 }),
         )
         .add_systems(Startup, create_scene)
-        .run()
+        .run();
 }
 
 fn create_scene(mut cmd: Commands) {

--- a/examples/screens.rs
+++ b/examples/screens.rs
@@ -1,8 +1,8 @@
-use std::time::Duration;
-
+use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen};
 use bevy_tweening::EaseFunction;
+use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Default, States, Hash, PartialEq, Eq)]
 enum ScreenStates {
@@ -33,7 +33,7 @@ fn main() {
                                     "by\n",
                                     TextStyle {
                                         font_size: 24.,
-                                        color: Color::WHITE.with_a(0.75),
+                                        color: Color::WHITE.with_alpha(0.75),
                                         ..default()
                                     },
                                 ),
@@ -49,7 +49,7 @@ fn main() {
                             .with_justify(JustifyText::Center),
                             "FiraSans-Bold.ttf".to_string(),
                         ),
-                        tint: Color::SEA_GREEN,
+                        tint: palettes::css::SEA_GREEN.into(),
                         width: Val::Percent(30.),
                         height: Val::Px(150.),
                         ease_function: EaseFunction::QuarticInOut.into(),
@@ -98,7 +98,7 @@ fn main() {
                             .with_justify(JustifyText::Center),
                             "FiraSans-Bold.ttf".to_string(),
                         ),
-                        tint: Color::RED,
+                        tint: Srgba::RED.into(),
                         width: Val::Percent(30.),
                         height: Val::Px(150.),
                         ease_function: EaseFunction::QuarticInOut.into(),
@@ -111,7 +111,7 @@ fn main() {
                 }),
         )
         .add_systems(Startup, create_scene)
-        .run()
+        .run();
 }
 
 fn create_scene(mut cmd: Commands) {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,8 +1,8 @@
-use std::time::Duration;
-
+use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen};
 use bevy_tweening::EaseFunction;
+use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Default, States, Hash, PartialEq, Eq)]
 enum ScreenStates {
@@ -35,7 +35,7 @@ fn main() {
                                         "by\n",
                                         TextStyle {
                                             font_size: 24.,
-                                            color: Color::WHITE.with_a(0.75),
+                                            color: Color::WHITE.with_alpha(0.75),
                                             ..default()
                                         },
                                     ),
@@ -43,7 +43,7 @@ fn main() {
                                         "Sergio Ribera",
                                         TextStyle {
                                             font_size: 32.,
-                                            color: Color::BLUE,
+                                            color: Srgba::BLUE.into(),
                                             ..default()
                                         },
                                     ),
@@ -51,7 +51,7 @@ fn main() {
                                 .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
-                            tint: Color::SEA_GREEN,
+                            tint: palettes::css::SEA_GREEN.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
                             ease_function: EaseFunction::QuarticInOut.into(),
@@ -73,7 +73,7 @@ fn main() {
                 }),
         )
         .add_systems(Startup, create_scene)
-        .run()
+        .run();
 }
 
 fn create_scene(mut cmd: Commands) {

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use bevy_tweening::lens::*;
+use bevy_tweening::Targetable;
 
 pub trait InstanceLens {
     fn create(start: Color, end: Color) -> Self;
@@ -27,14 +28,14 @@ impl SplashTextColorLens {
 }
 
 impl Lens<Text> for SplashTextColorLens {
-    fn lerp(&mut self, target: &mut Text, ratio: f32) {
+    fn lerp(&mut self, target: &mut dyn Targetable<Text>, ratio: f32) {
         target
             .sections
             .iter_mut()
             .enumerate()
             .for_each(|(i, section)| {
                 use crate::ColorLerper as _;
-                let value = self.0[i].with_a(0.).lerp(&self.0[i], ratio);
+                let value = self.0[i].with_alpha(0.).lerp(&self.0[i], ratio);
                 section.style.color = value;
             });
     }
@@ -46,10 +47,10 @@ impl InstanceLens for SplashImageColorLens {
     }
 }
 
-impl Lens<BackgroundColor> for SplashImageColorLens {
-    fn lerp(&mut self, target: &mut BackgroundColor, ratio: f32) {
+impl Lens<UiImage> for SplashImageColorLens {
+    fn lerp(&mut self, target: &mut dyn Targetable<UiImage>, ratio: f32) {
         use crate::ColorLerper as _;
         let value = self.start.lerp(&self.end, ratio);
-        target.0 = value;
+        target.color = value;
     }
 }

--- a/src/splash.rs
+++ b/src/splash.rs
@@ -118,7 +118,7 @@ pub(crate) fn create_splash(
                                     SplashTextColorLens::new(
                                         text.sections
                                             .iter()
-                                            .map(|_| Color::WHITE.with_a(0.))
+                                            .map(|_| Color::WHITE.with_alpha(0.))
                                             .collect(),
                                     ),
                                 )
@@ -148,6 +148,7 @@ pub(crate) fn create_splash(
                                 texture: assets.load(handler),
                                 flip_x: false,
                                 flip_y: false,
+                                ..default()
                             },
                             style: Style {
                                 width: brand.width,
@@ -156,7 +157,7 @@ pub(crate) fn create_splash(
                             },
                             ..default()
                         },
-                        create_animator::<BackgroundColor, SplashImageColorLens>(
+                        create_animator::<UiImage, SplashImageColorLens>(
                             brand,
                             max_duration,
                             i_screen,
@@ -181,14 +182,14 @@ where
         Tween::new(
             brand.ease_function,
             Duration::from_secs(1),
-            L::create(brand.tint.with_a(0.), brand.tint.with_a(0.)),
+            L::create(brand.tint.with_alpha(0.), brand.tint.with_alpha(0.)),
         )
         .then(
             Delay::new(max_duration).then(
                 Tween::new(
                     brand.ease_function,
                     brand.duration,
-                    L::create(brand.tint.with_a(0.), brand.tint),
+                    L::create(brand.tint.with_alpha(0.), brand.tint),
                 )
                 .with_repeat_strategy(RepeatStrategy::MirroredRepeat)
                 .with_repeat_count(RepeatCount::Finite(2))

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use bevy::{
     input::{gamepad::GamepadEvent, keyboard::KeyboardInput, mouse::MouseButtonInput},
     prelude::*,
+    state::state::{FreelyMutableState, NextState, States},
 };
 use bevy_tweening::TweenCompleted;
 
@@ -25,7 +26,7 @@ pub(crate) struct SplashBackground {
 //
 // Remove all nodes when splash end
 //
-pub(crate) fn splash_end<'a, S: States>(
+pub(crate) fn splash_end<'a, S: FreelyMutableState>(
     mut cmd: Commands,
     next_state: S,
     brands: impl Iterator<Item = (Entity, &'a Node, &'a ClearSplash)>,
@@ -33,13 +34,13 @@ pub(crate) fn splash_end<'a, S: States>(
     for (entity, _, _) in brands {
         cmd.entity(entity).despawn_recursive();
     }
-    cmd.insert_resource(NextState(Some(next_state)));
+    cmd.insert_resource(NextState::Pending(next_state));
 }
 
 //
 // Logic to end splash and change background color
 //
-pub(crate) fn update_splash<S: States>(
+pub(crate) fn update_splash<S: FreelyMutableState>(
     cmd: Commands,
     brands: Query<(Entity, &Node, &ClearSplash)>,
     mut background: Query<(&Node, &mut BackgroundColor, &SplashBackground)>,
@@ -78,7 +79,7 @@ pub(crate) fn update_splash<S: States>(
 //
 // System for skip splash
 //
-pub(crate) fn splash_skip<S: States>(
+pub(crate) fn splash_skip<S: FreelyMutableState>(
     cmd: Commands,
     mut kbd: EventReader<KeyboardInput>,
     mut mouse: EventReader<MouseButtonInput>,


### PR DESCRIPTION
Made a pull-request to your bevy_tweening fork as well.

The behavior of the examples is a bit different now but after looking at their code, it looks like it's more correct now?
For example with the simple example both the text and brand image appear and disappear at the same time now, which seems in line with what the code tries to do, but maybe I misunderstood something.

Also text is centered now instead of slightly offset to the left.