### PR TITLE
Upgrade to bevy 0.16

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="ALL" />
+  </component>
+  <component name="CargoProjects">
+    <cargoProject FILE="$PROJECT_DIR$/Cargo.toml" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="f8faf566-c6a4-4097-a154-21913dff816f" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/Cargo.toml" beforeDir="false" afterPath="$PROJECT_DIR$/Cargo.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/examples/custom_skip.rs" beforeDir="false" afterPath="$PROJECT_DIR$/examples/custom_skip.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/examples/layouts.rs" beforeDir="false" afterPath="$PROJECT_DIR$/examples/layouts.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/examples/screens.rs" beforeDir="false" afterPath="$PROJECT_DIR$/examples/screens.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/examples/simple.rs" beforeDir="false" afterPath="$PROJECT_DIR$/examples/simple.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lens.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/lens.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/splash.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/splash.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/systems.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/systems.rs" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MacroExpansionManager">
+    <option name="directoryName" value="xpa88qoh" />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;customColor&quot;: &quot;&quot;,
+  &quot;associatedIndex&quot;: 6
+}</component>
+  <component name="ProjectId" id="2wsWfoklyw3nzTuXhddgr909jkT" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Cargo.Run custom_skip.executor": "Debug",
+    "Cargo.Run layouts.executor": "Debug",
+    "Cargo.Run screens.executor": "Run",
+    "Cargo.Run simple.executor": "Run",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.rust.reset.selective.auto.import": "true",
+    "git-widget-placeholder": "main",
+    "last_opened_file_path": "C:/Users/rezan/Repositories/bevy_snake",
+    "node.js.detected.package.eslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "org.rust.cargo.project.model.PROJECT_DISCOVERY": "true",
+    "org.rust.cargo.project.model.impl.CargoExternalSystemProjectAware.subscribe.first.balloon": ""
+  }
+}]]></component>
+  <component name="RunManager" selected="Cargo.Run screens">
+    <configuration name="Run custom_skip" type="CargoCommandRunConfiguration" factoryName="Cargo Command" temporary="true">
+      <option name="command" value="run --package bevy_splash_screen --example custom_skip" />
+      <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+      <envs />
+      <option name="emulateTerminal" value="true" />
+      <option name="channel" value="DEFAULT" />
+      <option name="requiredFeatures" value="true" />
+      <option name="allFeatures" value="false" />
+      <option name="withSudo" value="false" />
+      <option name="buildTarget" value="REMOTE" />
+      <option name="backtrace" value="SHORT" />
+      <option name="isRedirectInput" value="false" />
+      <option name="redirectInputPath" value="" />
+      <method v="2">
+        <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="Run layouts" type="CargoCommandRunConfiguration" factoryName="Cargo Command" temporary="true">
+      <option name="command" value="run --package bevy_splash_screen --example layouts" />
+      <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+      <envs />
+      <option name="emulateTerminal" value="true" />
+      <option name="channel" value="DEFAULT" />
+      <option name="requiredFeatures" value="true" />
+      <option name="allFeatures" value="false" />
+      <option name="withSudo" value="false" />
+      <option name="buildTarget" value="REMOTE" />
+      <option name="backtrace" value="SHORT" />
+      <option name="isRedirectInput" value="false" />
+      <option name="redirectInputPath" value="" />
+      <method v="2">
+        <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="Run screens" type="CargoCommandRunConfiguration" factoryName="Cargo Command" temporary="true">
+      <option name="command" value="run --package bevy_splash_screen --example screens" />
+      <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+      <envs />
+      <option name="emulateTerminal" value="true" />
+      <option name="channel" value="DEFAULT" />
+      <option name="requiredFeatures" value="true" />
+      <option name="allFeatures" value="false" />
+      <option name="withSudo" value="false" />
+      <option name="buildTarget" value="REMOTE" />
+      <option name="backtrace" value="SHORT" />
+      <option name="isRedirectInput" value="false" />
+      <option name="redirectInputPath" value="" />
+      <method v="2">
+        <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="Run simple" type="CargoCommandRunConfiguration" factoryName="Cargo Command" temporary="true">
+      <option name="command" value="run --package bevy_splash_screen --example simple" />
+      <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+      <envs />
+      <option name="emulateTerminal" value="true" />
+      <option name="channel" value="DEFAULT" />
+      <option name="requiredFeatures" value="true" />
+      <option name="allFeatures" value="false" />
+      <option name="withSudo" value="false" />
+      <option name="buildTarget" value="REMOTE" />
+      <option name="backtrace" value="SHORT" />
+      <option name="isRedirectInput" value="false" />
+      <option name="redirectInputPath" value="" />
+      <method v="2">
+        <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+      </method>
+    </configuration>
+    <recent_temporary>
+      <list>
+        <item itemvalue="Cargo.Run screens" />
+        <item itemvalue="Cargo.Run layouts" />
+        <item itemvalue="Cargo.Run simple" />
+        <item itemvalue="Cargo.Run custom_skip" />
+      </list>
+    </recent_temporary>
+  </component>
+  <component name="RustProjectSettings">
+    <option name="toolchainHomeDirectory" value="$USER_HOME$/.cargo/bin" />
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="f8faf566-c6a4-4097-a154-21913dff816f" name="Changes" comment="" />
+      <created>1746830868561</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1746830868561</updated>
+      <workItem from="1746830869989" duration="30659000" />
+      <workItem from="1748382153026" duration="5436000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,13 @@ opt-level = 1
 opt-level = 3
 
 [dev-dependencies]
-bevy = { version = "0.13", default-features = false, features = [
-    "multi-threaded",
+bevy = { version = "0.14.1", default-features = false, features = [
+    "multi_threaded",
     "bevy_asset",
     "bevy_winit",
     "bevy_render",
     "bevy_sprite",
+    "bevy_state",
     "png",
 ] }
 
@@ -35,9 +36,10 @@ dev = [
     "bevy/bevy_core_pipeline",
     "bevy/bevy_render",
     "bevy/bevy_sprite",
+    "bevy/bevy_state",
     "bevy/bevy_text",
     "bevy/bevy_ui",
-    "bevy/multi-threaded",
+    "bevy/multi_threaded",
     "bevy/png",
     "bevy/ktx2",
     "bevy/x11",
@@ -66,8 +68,10 @@ required-features = ["dev"]
 path = "./examples/simple.rs"
 
 [dependencies]
-bevy = { version = "0.13", default-features = false }
-bevy_tweening = "0.10"
+bevy = { version = "0.14.1", default-features = false , features = [
+    "bevy_state",
+] }
+bevy_tweening = "0.11.0"
 
 [patch.crates-io]
 bevy_tweening = { git = "https://github.com/SergioRibera/bevy_tweening", branch = "infinite_mirrored" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ opt-level = 0
 opt-level = 3
 
 [dev-dependencies]
-bevy = { version = "0.15.3", default-features = false, features = [
+bevy = { version = "0.16.0", default-features = false, features = [
     "multi_threaded",
     "bevy_asset",
     "bevy_winit",
@@ -68,11 +68,11 @@ required-features = ["dev"]
 path = "./examples/simple.rs"
 
 [dependencies]
-bevy = { version = "0.15.3", default-features = false , features = [
+bevy = { version = "0.16.0", default-features = false , features = [
     "bevy_state",
 ] }
-bevy_math = "0.15.3"
-bevy_tweening = "0.11.0"
+bevy_math = "0.16.0"
+bevy_tweening = "0.13.0"
 
 [patch.crates-io]
-bevy_tweening = { git = "https://github.com/SergioRibera/bevy_tweening", branch = "infinite_mirrored" }
+bevy_tweening = { git = "https://github.com/Rezan7CC/bevy_tweening", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_splash_screen"
 description = "A plugin for bevy which allows you to create screens to show the brands and development teams behind your amazing game"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/SergioRibera/bevy_splash_screen"
@@ -11,13 +11,13 @@ keywords = ["gamedev", "ui", "bevy"]
 resolver = "2"
 
 [profile.dev]
-opt-level = 1
+opt-level = 0
 
 [profile.dev.package."*"]
 opt-level = 3
 
 [dev-dependencies]
-bevy = { version = "0.14.1", default-features = false, features = [
+bevy = { version = "0.15.3", default-features = false, features = [
     "multi_threaded",
     "bevy_asset",
     "bevy_winit",
@@ -68,10 +68,8 @@ required-features = ["dev"]
 path = "./examples/simple.rs"
 
 [dependencies]
-bevy = { version = "0.14.1", default-features = false , features = [
+bevy = { version = "0.15.3", default-features = false , features = [
     "bevy_state",
 ] }
-bevy_tweening = "0.11.0"
-
-[patch.crates-io]
-bevy_tweening = { git = "https://github.com/SergioRibera/bevy_tweening", branch = "infinite_mirrored" }
+bevy_math = "0.15.3"
+bevy_tweening = { git = "https://github.com/Rezan7CC/bevy_tweening", rev = "6ef369e" }

--- a/README.md
+++ b/README.md
@@ -10,12 +10,14 @@
 # Versions
 Aviable and compatible versions
 
-|  bevy  |   SplashScreen  |
-|--------|-----------------|
-|  0.13  |      0.6.0      |
-|  0.12  |      0.5.0      |
-|  0.11  |      0.4.4      |
-| 0.10.1 |      0.3.0      |
+| bevy   | SplashScreen |
+|--------|--------------|
+| 0.16   | 0.8.0        |
+| 0.15   | 0.7.0        |
+| 0.13   | 0.6.0        |
+| 0.12   | 0.5.0        |
+| 0.11   | 0.4.4        |
+| 0.10.1 | 0.3.0        |
 
 # Features
 - Suport multiple screens (Multiple brands on sequencial screens)

--- a/examples/custom_skip.rs
+++ b/examples/custom_skip.rs
@@ -80,7 +80,7 @@ fn main() {
         )
         .add_systems(Startup, create_scene)
         .add_systems(Update, button_system)
-        .run()
+        .run();
 }
 
 fn create_scene(mut cmd: Commands, assets: ResMut<AssetServer>) {
@@ -110,7 +110,7 @@ fn create_scene(mut cmd: Commands, assets: ResMut<AssetServer>) {
                 align_items: AlignItems::Center,
                 ..default()
             },
-            background_color: BackgroundColor(Color::WHITE.with_a(0.)),
+            background_color: BackgroundColor(Color::WHITE.with_alpha(0.)),
             ..default()
         })
         .with_children(|cmd| {
@@ -146,9 +146,8 @@ fn button_system(
     mut send_skip: EventWriter<SplashScreenSkipEvent>,
 ) {
     for interaction in &mut interaction_query {
-        match *interaction {
-            Interaction::Pressed => send_skip.send(SplashScreenSkipEvent),
-            _ => {}
+        if *interaction == Interaction::Pressed {
+            send_skip.send(SplashScreenSkipEvent);
         }
     }
 }

--- a/examples/custom_skip.rs
+++ b/examples/custom_skip.rs
@@ -1,10 +1,7 @@
 use std::time::Duration;
 
 use bevy::prelude::*;
-use bevy_splash_screen::{
-    ClearSplash, SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashScreenSkipEvent,
-    SplashTextColorLens,
-};
+use bevy_splash_screen::{ClearSplash, SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashScreenSkipEvent, SplashText, SplashTextColorLens, SplashTextSection};
 use bevy_tweening::*;
 
 #[derive(Clone, Copy, Debug, Default, States, Hash, PartialEq, Eq)]
@@ -24,26 +21,23 @@ fn main() {
                 .skipable()
                 .add_screen(SplashScreen {
                     brands: vec![SplashItem {
-                        asset: SplashAssetType::SingleText(
-                            Text::from_sections([
-                                TextSection::new(
-                                    "Sergio Ribera\n",
-                                    TextStyle {
-                                        font_size: 76.,
-                                        ..default()
-                                    },
-                                ),
-                                TextSection::new(
-                                    "presents\n",
-                                    TextStyle {
-                                        font_size: 38.,
-                                        ..default()
-                                    },
-                                ),
-                            ])
-                            .with_justify(JustifyText::Center),
-                            "FiraSans-Bold.ttf".to_string(),
-                        ),
+                        asset: SplashAssetType::SingleText(SplashText {
+                            sections: vec![
+                                SplashTextSection {
+                                    text: "Sergio Ribera\n".into(),
+                                    text_font: "FiraSans-Bold.ttf".to_string(),
+                                    text_size: 76.,
+                                    text_color: Color::WHITE.into(),
+                                },
+                                SplashTextSection {
+                                    text: "presents\n".into(),
+                                    text_font: "FiraSans-Bold.ttf".to_string(),
+                                    text_size: 38.,
+                                    text_color: Color::WHITE.with_alpha(0.75).into(),
+                                },
+                            ],
+                            text_alignment: JustifyText::Center,
+                        }),
                         tint: Color::WHITE,
                         width: Val::Percent(40.),
                         height: Val::Px(80.),
@@ -56,17 +50,17 @@ fn main() {
                 })
                 .add_screen(SplashScreen {
                     brands: vec![SplashItem {
-                        asset: SplashAssetType::SingleText(
-                            Text::from_section(
-                                "Custom Skip\n",
-                                TextStyle {
-                                    font_size: 75.,
-                                    ..default()
+                        asset: SplashAssetType::SingleText(SplashText {
+                            sections: vec![
+                                SplashTextSection {
+                                    text: "Custom Skip\n".into(),
+                                    text_font: "FiraSans-Bold.ttf".to_string(),
+                                    text_size: 75.,
+                                    text_color: Color::WHITE.into(),
                                 },
-                            )
-                            .with_justify(JustifyText::Center),
-                            "FiraSans-Bold.ttf".to_string(),
-                        ),
+                            ],
+                            text_alignment: JustifyText::Center,
+                        }),
                         tint: Color::WHITE,
                         width: Val::Percent(35.),
                         height: Val::Px(160.),
@@ -84,54 +78,41 @@ fn main() {
 }
 
 fn create_scene(mut cmd: Commands, assets: ResMut<AssetServer>) {
-    cmd.spawn(Camera2dBundle::default());
+    cmd.spawn(Camera2d::default());
 
-    cmd.spawn(NodeBundle {
-        style: Style {
-            display: Display::Flex,
-            position_type: PositionType::Absolute,
-            direction: Direction::LeftToRight,
-            align_items: AlignItems::FlexEnd,
-            align_content: AlignContent::Center,
-            justify_content: JustifyContent::Center,
-            width: Val::Percent(100.),
-            height: Val::Percent(100.),
-            overflow: Overflow::clip(),
-            ..default()
-        },
+    cmd.spawn(Node {
+        display: Display::Flex,
+        position_type: PositionType::Absolute,
+        align_items: AlignItems::FlexEnd,
+        align_content: AlignContent::Center,
+        justify_content: JustifyContent::Center,
+        width: Val::Percent(100.),
+        height: Val::Percent(100.),
+        overflow: Overflow::clip(),
         ..default()
     })
     .insert(ClearSplash)
     .with_children(|cmd| {
-        cmd.spawn(ButtonBundle {
-            style: Style {
-                height: Val::Px(65.0),
-                justify_content: JustifyContent::Center,
-                align_items: AlignItems::Center,
-                ..default()
-            },
-            background_color: BackgroundColor(Color::WHITE.with_alpha(0.)),
+        cmd.spawn((Button::default(), 
+          Node {
+            height: Val::Px(65.0),
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
             ..default()
-        })
+        }, BackgroundColor(Color::WHITE.with_alpha(0.))))
         .with_children(|cmd| {
             cmd.spawn((
-                TextBundle {
-                    text: Text::from_section(
-                        "Press Any Key or Touch screen for skip",
-                        TextStyle {
-                            font_size: 50.,
-                            font: assets.load("FiraSans-Bold.ttf"),
-                            ..default()
-                        },
-                    )
-                    .with_justify(JustifyText::Center),
+                Text("Press Any Key or Touch screen for skip".into()),
+                TextFont {
+                    font: assets.load("FiraSans-Bold.ttf"),
+                    font_size: 50.,
                     ..default()
                 },
                 Animator::new(
                     Tween::new(
                         EaseFunction::QuadraticInOut,
                         Duration::from_secs(3),
-                        SplashTextColorLens::new(vec![Color::WHITE]),
+                        SplashTextColorLens::new(Color::WHITE),
                     )
                     .with_repeat_count(RepeatCount::Infinite)
                     .with_repeat_strategy(RepeatStrategy::MirroredRepeat),

--- a/examples/custom_skip.rs
+++ b/examples/custom_skip.rs
@@ -128,7 +128,7 @@ fn button_system(
 ) {
     for interaction in &mut interaction_query {
         if *interaction == Interaction::Pressed {
-            send_skip.send(SplashScreenSkipEvent);
+            send_skip.write(SplashScreenSkipEvent);
         }
     }
 }

--- a/examples/custom_skip.rs
+++ b/examples/custom_skip.rs
@@ -1,7 +1,10 @@
 use std::time::Duration;
 
 use bevy::prelude::*;
-use bevy_splash_screen::{ClearSplash, SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashScreenSkipEvent, SplashText, SplashTextColorLens, SplashTextSection};
+use bevy_splash_screen::{
+    ClearSplash, SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashScreenSkipEvent,
+    SplashText, SplashTextColorLens, SplashTextSection,
+};
 use bevy_tweening::*;
 
 #[derive(Clone, Copy, Debug, Default, States, Hash, PartialEq, Eq)]
@@ -51,14 +54,12 @@ fn main() {
                 .add_screen(SplashScreen {
                     brands: vec![SplashItem {
                         asset: SplashAssetType::SingleText(SplashText {
-                            sections: vec![
-                                SplashTextSection {
-                                    text: "Custom Skip\n".into(),
-                                    text_font: "FiraSans-Bold.ttf".to_string(),
-                                    text_size: 75.,
-                                    text_color: Color::WHITE.into(),
-                                },
-                            ],
+                            sections: vec![SplashTextSection {
+                                text: "Custom Skip\n".into(),
+                                text_font: "FiraSans-Bold.ttf".to_string(),
+                                text_size: 75.,
+                                text_color: Color::WHITE.into(),
+                            }],
                             text_alignment: JustifyText::Center,
                         }),
                         tint: Color::WHITE,
@@ -93,13 +94,16 @@ fn create_scene(mut cmd: Commands, assets: ResMut<AssetServer>) {
     })
     .insert(ClearSplash)
     .with_children(|cmd| {
-        cmd.spawn((Button::default(), 
-          Node {
-            height: Val::Px(65.0),
-            justify_content: JustifyContent::Center,
-            align_items: AlignItems::Center,
-            ..default()
-        }, BackgroundColor(Color::WHITE.with_alpha(0.))))
+        cmd.spawn((
+            Button::default(),
+            Node {
+                height: Val::Px(65.0),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                ..default()
+            },
+            BackgroundColor(Color::WHITE.with_alpha(0.)),
+        ))
         .with_children(|cmd| {
             cmd.spawn((
                 Text("Press Any Key or Touch screen for skip".into()),

--- a/examples/layouts.rs
+++ b/examples/layouts.rs
@@ -1,8 +1,8 @@
-use std::time::Duration;
-
+use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashType};
 use bevy_tweening::EaseFunction;
+use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Default, States, Hash, PartialEq, Eq)]
 enum ScreenStates {
@@ -35,7 +35,7 @@ fn main() {
                                         "by\n",
                                         TextStyle {
                                             font_size: 24.,
-                                            color: Color::WHITE.with_a(0.75),
+                                            color: Color::WHITE.with_alpha(0.75),
                                             ..default()
                                         },
                                     ),
@@ -51,7 +51,7 @@ fn main() {
                                 .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
-                            tint: Color::SEA_GREEN,
+                            tint: palettes::css::SEA_GREEN.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
                             ease_function: EaseFunction::QuarticInOut.into(),
@@ -98,7 +98,7 @@ fn main() {
                                 .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
-                            tint: Color::YELLOW,
+                            tint: palettes::basic::YELLOW.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
                             ease_function: EaseFunction::QuarticInOut.into(),
@@ -118,7 +118,7 @@ fn main() {
                                 .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
-                            tint: Color::BLUE,
+                            tint: Srgba::BLUE.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
                             ease_function: EaseFunction::QuarticInOut.into(),
@@ -158,7 +158,7 @@ fn main() {
                                 .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
-                            tint: Color::PURPLE,
+                            tint: palettes::basic::PURPLE.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
                             ease_function: EaseFunction::QuarticInOut.into(),
@@ -173,7 +173,7 @@ fn main() {
                 }),
         )
         .add_systems(Startup, create_scene)
-        .run()
+        .run();
 }
 
 fn create_scene(mut cmd: Commands) {

--- a/examples/layouts.rs
+++ b/examples/layouts.rs
@@ -1,7 +1,6 @@
 use bevy::color::palettes;
 use bevy::prelude::*;
-use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashType};
-use bevy_tweening::EaseFunction;
+use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashText, SplashTextSection, SplashType};
 use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Default, States, Hash, PartialEq, Eq)]
@@ -21,36 +20,29 @@ fn main() {
                 .add_screen(SplashScreen {
                     brands: vec![
                         SplashItem {
-                            asset: SplashAssetType::SingleText(
-                                Text::from_sections([
-                                    TextSection::new(
-                                        "Simple Test\n",
-                                        TextStyle {
-                                            font_size: 40.,
-                                            color: Color::WHITE,
-                                            ..default()
-                                        },
-                                    ),
-                                    TextSection::new(
-                                        "by\n",
-                                        TextStyle {
-                                            font_size: 24.,
-                                            color: Color::WHITE.with_alpha(0.75),
-                                            ..default()
-                                        },
-                                    ),
-                                    TextSection::new(
-                                        "Sergio Ribera",
-                                        TextStyle {
-                                            font_size: 32.,
-                                            color: Color::WHITE,
-                                            ..default()
-                                        },
-                                    ),
-                                ])
-                                .with_justify(JustifyText::Center),
-                                "FiraSans-Bold.ttf".to_string(),
-                            ),
+                            asset: SplashAssetType::SingleText(SplashText {
+                                sections: vec![
+                                    SplashTextSection {
+                                        text: "Simple Test\n".into(),
+                                        text_font: "FiraSans-Bold.ttf".to_string(),
+                                        text_size: 40.,
+                                        text_color: Color::WHITE.into(),
+                                    },
+                                    SplashTextSection {
+                                        text: "by\n".into(),
+                                        text_font: "FiraSans-Bold.ttf".to_string(),
+                                        text_size: 24.,
+                                        text_color: Color::WHITE.with_alpha(0.75).into(),
+                                    },
+                                    SplashTextSection {
+                                        text: "Sergio Ribera".into(),
+                                        text_font: "FiraSans-Bold.ttf".to_string(),
+                                        text_size: 32.,
+                                        text_color: Srgba::WHITE.into(),
+                                    },
+                                ],
+                                text_alignment: JustifyText::Center,
+                            }),
                             tint: palettes::css::SEA_GREEN.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
@@ -59,18 +51,17 @@ fn main() {
                             is_static: false,
                         },
                         SplashItem {
-                            asset: SplashAssetType::SingleText(
-                                Text::from_sections([TextSection::new(
-                                    "With Bevy",
-                                    TextStyle {
-                                        font_size: 32.,
-                                        color: Color::WHITE,
-                                        ..default()
-                                    },
-                                )])
-                                .with_justify(JustifyText::Center),
-                                "FiraSans-Bold.ttf".to_string(),
-                            ),
+                            asset: SplashAssetType::SingleText(SplashText {
+                                sections: vec![
+                                    SplashTextSection {
+                                        text: "With Bevy".into(),
+                                        text_font: "FiraSans-Bold.ttf".to_string(),
+                                        text_size: 32.,
+                                        text_color: Color::WHITE.into(),
+                                    }
+                                ],
+                                text_alignment: JustifyText::Center,
+                            }),
                             tint: Color::WHITE,
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
@@ -86,18 +77,17 @@ fn main() {
                 .add_screen(SplashScreen {
                     brands: vec![
                         SplashItem {
-                            asset: SplashAssetType::SingleText(
-                                Text::from_sections([TextSection::new(
-                                    "Hola Hola Hola",
-                                    TextStyle {
-                                        font_size: 32.,
-                                        color: Color::WHITE,
-                                        ..default()
-                                    },
-                                )])
-                                .with_justify(JustifyText::Center),
-                                "FiraSans-Bold.ttf".to_string(),
-                            ),
+                            asset: SplashAssetType::SingleText(SplashText {
+                                sections: vec![
+                                    SplashTextSection {
+                                        text: "Hola Hola Hola".into(),
+                                        text_font: "FiraSans-Bold.ttf".to_string(),
+                                        text_size: 32.,
+                                        text_color: Color::WHITE.into(),
+                                    }
+                                ],
+                                text_alignment: JustifyText::Center,
+                            }),
                             tint: palettes::basic::YELLOW.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
@@ -106,38 +96,36 @@ fn main() {
                             is_static: false,
                         },
                         SplashItem {
-                            asset: SplashAssetType::SingleText(
-                                Text::from_sections([TextSection::new(
-                                    "Hello Hello Hello",
-                                    TextStyle {
-                                        font_size: 32.,
-                                        color: Color::WHITE,
-                                        ..default()
-                                    },
-                                )])
-                                .with_justify(JustifyText::Center),
-                                "FiraSans-Bold.ttf".to_string(),
-                            ),
+                            asset: SplashAssetType::SingleText(SplashText {
+                                sections: vec![
+                                    SplashTextSection {
+                                        text: "Hello Hello Hello".into(),
+                                        text_font: "FiraSans-Bold.ttf".to_string(),
+                                        text_size: 32.,
+                                        text_color: Color::WHITE.into(),
+                                    }
+                                ],
+                                text_alignment: JustifyText::Center,
+                            }),
                             tint: Srgba::BLUE.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
                             ease_function: EaseFunction::QuarticInOut.into(),
-                            duration: Duration::from_secs_f32(12.),
+                            duration: Duration::from_secs_f32(5.),
                             is_static: false,
                         },
                         SplashItem {
-                            asset: SplashAssetType::SingleText(
-                                Text::from_sections([TextSection::new(
-                                    "Test Test Test",
-                                    TextStyle {
-                                        font_size: 32.,
-                                        color: Color::WHITE,
-                                        ..default()
-                                    },
-                                )])
-                                .with_justify(JustifyText::Center),
-                                "FiraSans-Bold.ttf".to_string(),
-                            ),
+                            asset: SplashAssetType::SingleText(SplashText {
+                                sections: vec![
+                                    SplashTextSection {
+                                        text: "Test Test Test".into(),
+                                        text_font: "FiraSans-Bold.ttf".to_string(),
+                                        text_size: 32.,
+                                        text_color: Color::WHITE.into(),
+                                    }
+                                ],
+                                text_alignment: JustifyText::Center,
+                            }),
                             tint: Color::WHITE,
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
@@ -146,18 +134,17 @@ fn main() {
                             is_static: false,
                         },
                         SplashItem {
-                            asset: SplashAssetType::SingleText(
-                                Text::from_sections([TextSection::new(
-                                    "Bevy Bevy Bevy",
-                                    TextStyle {
-                                        font_size: 32.,
-                                        color: Color::WHITE,
-                                        ..default()
-                                    },
-                                )])
-                                .with_justify(JustifyText::Center),
-                                "FiraSans-Bold.ttf".to_string(),
-                            ),
+                            asset: SplashAssetType::SingleText(SplashText {
+                                sections: vec![
+                                    SplashTextSection {
+                                        text: "Bevy Bevy Bevy".into(),
+                                        text_font: "FiraSans-Bold.ttf".to_string(),
+                                        text_size: 32.,
+                                        text_color: Color::WHITE.into(),
+                                    }
+                                ],
+                                text_alignment: JustifyText::Center,
+                            }),
                             tint: palettes::basic::PURPLE.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
@@ -177,5 +164,5 @@ fn main() {
 }
 
 fn create_scene(mut cmd: Commands) {
-    cmd.spawn(Camera2dBundle::default());
+    cmd.spawn(Camera2d::default());
 }

--- a/examples/layouts.rs
+++ b/examples/layouts.rs
@@ -1,6 +1,9 @@
 use bevy::color::palettes;
 use bevy::prelude::*;
-use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashText, SplashTextSection, SplashType};
+use bevy_splash_screen::{
+    SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashText, SplashTextSection,
+    SplashType,
+};
 use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Default, States, Hash, PartialEq, Eq)]
@@ -52,14 +55,12 @@ fn main() {
                         },
                         SplashItem {
                             asset: SplashAssetType::SingleText(SplashText {
-                                sections: vec![
-                                    SplashTextSection {
-                                        text: "With Bevy".into(),
-                                        text_font: "FiraSans-Bold.ttf".to_string(),
-                                        text_size: 32.,
-                                        text_color: Color::WHITE.into(),
-                                    }
-                                ],
+                                sections: vec![SplashTextSection {
+                                    text: "With Bevy".into(),
+                                    text_font: "FiraSans-Bold.ttf".to_string(),
+                                    text_size: 32.,
+                                    text_color: Color::WHITE.into(),
+                                }],
                                 text_alignment: JustifyText::Center,
                             }),
                             tint: Color::WHITE,
@@ -78,14 +79,12 @@ fn main() {
                     brands: vec![
                         SplashItem {
                             asset: SplashAssetType::SingleText(SplashText {
-                                sections: vec![
-                                    SplashTextSection {
-                                        text: "Hola Hola Hola".into(),
-                                        text_font: "FiraSans-Bold.ttf".to_string(),
-                                        text_size: 32.,
-                                        text_color: Color::WHITE.into(),
-                                    }
-                                ],
+                                sections: vec![SplashTextSection {
+                                    text: "Hola Hola Hola".into(),
+                                    text_font: "FiraSans-Bold.ttf".to_string(),
+                                    text_size: 32.,
+                                    text_color: Color::WHITE.into(),
+                                }],
                                 text_alignment: JustifyText::Center,
                             }),
                             tint: palettes::basic::YELLOW.into(),
@@ -97,14 +96,12 @@ fn main() {
                         },
                         SplashItem {
                             asset: SplashAssetType::SingleText(SplashText {
-                                sections: vec![
-                                    SplashTextSection {
-                                        text: "Hello Hello Hello".into(),
-                                        text_font: "FiraSans-Bold.ttf".to_string(),
-                                        text_size: 32.,
-                                        text_color: Color::WHITE.into(),
-                                    }
-                                ],
+                                sections: vec![SplashTextSection {
+                                    text: "Hello Hello Hello".into(),
+                                    text_font: "FiraSans-Bold.ttf".to_string(),
+                                    text_size: 32.,
+                                    text_color: Color::WHITE.into(),
+                                }],
                                 text_alignment: JustifyText::Center,
                             }),
                             tint: Srgba::BLUE.into(),
@@ -116,14 +113,12 @@ fn main() {
                         },
                         SplashItem {
                             asset: SplashAssetType::SingleText(SplashText {
-                                sections: vec![
-                                    SplashTextSection {
-                                        text: "Test Test Test".into(),
-                                        text_font: "FiraSans-Bold.ttf".to_string(),
-                                        text_size: 32.,
-                                        text_color: Color::WHITE.into(),
-                                    }
-                                ],
+                                sections: vec![SplashTextSection {
+                                    text: "Test Test Test".into(),
+                                    text_font: "FiraSans-Bold.ttf".to_string(),
+                                    text_size: 32.,
+                                    text_color: Color::WHITE.into(),
+                                }],
                                 text_alignment: JustifyText::Center,
                             }),
                             tint: Color::WHITE,
@@ -135,14 +130,12 @@ fn main() {
                         },
                         SplashItem {
                             asset: SplashAssetType::SingleText(SplashText {
-                                sections: vec![
-                                    SplashTextSection {
-                                        text: "Bevy Bevy Bevy".into(),
-                                        text_font: "FiraSans-Bold.ttf".to_string(),
-                                        text_size: 32.,
-                                        text_color: Color::WHITE.into(),
-                                    }
-                                ],
+                                sections: vec![SplashTextSection {
+                                    text: "Bevy Bevy Bevy".into(),
+                                    text_font: "FiraSans-Bold.ttf".to_string(),
+                                    text_size: 32.,
+                                    text_color: Color::WHITE.into(),
+                                }],
                                 text_alignment: JustifyText::Center,
                             }),
                             tint: palettes::basic::PURPLE.into(),

--- a/examples/screens.rs
+++ b/examples/screens.rs
@@ -1,8 +1,8 @@
-use std::time::Duration;
-
+use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen};
 use bevy_tweening::EaseFunction;
+use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Default, States, Hash, PartialEq, Eq)]
 enum ScreenStates {
@@ -33,7 +33,7 @@ fn main() {
                                     "by\n",
                                     TextStyle {
                                         font_size: 24.,
-                                        color: Color::WHITE.with_a(0.75),
+                                        color: Color::WHITE.with_alpha(0.75),
                                         ..default()
                                     },
                                 ),
@@ -49,7 +49,7 @@ fn main() {
                             .with_justify(JustifyText::Center),
                             "FiraSans-Bold.ttf".to_string(),
                         ),
-                        tint: Color::SEA_GREEN,
+                        tint: palettes::css::SEA_GREEN.into(),
                         width: Val::Percent(30.),
                         height: Val::Px(150.),
                         ease_function: EaseFunction::QuarticInOut.into(),
@@ -98,7 +98,7 @@ fn main() {
                             .with_justify(JustifyText::Center),
                             "FiraSans-Bold.ttf".to_string(),
                         ),
-                        tint: Color::RED,
+                        tint: Srgba::RED.into(),
                         width: Val::Percent(30.),
                         height: Val::Px(150.),
                         ease_function: EaseFunction::QuarticInOut.into(),
@@ -111,7 +111,7 @@ fn main() {
                 }),
         )
         .add_systems(Startup, create_scene)
-        .run()
+        .run();
 }
 
 fn create_scene(mut cmd: Commands) {

--- a/examples/screens.rs
+++ b/examples/screens.rs
@@ -1,7 +1,6 @@
 use bevy::color::palettes;
 use bevy::prelude::*;
-use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen};
-use bevy_tweening::EaseFunction;
+use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashText, SplashTextSection};
 use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Default, States, Hash, PartialEq, Eq)]
@@ -19,36 +18,29 @@ fn main() {
             SplashPlugin::new(ScreenStates::Splash, ScreenStates::Menu)
                 .add_screen(SplashScreen {
                     brands: vec![SplashItem {
-                        asset: SplashAssetType::SingleText(
-                            Text::from_sections([
-                                TextSection::new(
-                                    "Simple Test\n",
-                                    TextStyle {
-                                        font_size: 40.,
-                                        color: Color::WHITE,
-                                        ..default()
-                                    },
-                                ),
-                                TextSection::new(
-                                    "by\n",
-                                    TextStyle {
-                                        font_size: 24.,
-                                        color: Color::WHITE.with_alpha(0.75),
-                                        ..default()
-                                    },
-                                ),
-                                TextSection::new(
-                                    "Sergio Ribera",
-                                    TextStyle {
-                                        font_size: 32.,
-                                        color: Color::WHITE,
-                                        ..default()
-                                    },
-                                ),
-                            ])
-                            .with_justify(JustifyText::Center),
-                            "FiraSans-Bold.ttf".to_string(),
-                        ),
+                        asset: SplashAssetType::SingleText(SplashText {
+                            sections: vec![
+                                SplashTextSection {
+                                    text: "Simple Test\n".into(),
+                                    text_font: "FiraSans-Bold.ttf".to_string(),
+                                    text_size: 40.,
+                                    text_color: Color::WHITE.into(),
+                                },
+                                SplashTextSection {
+                                    text: "by\n".into(),
+                                    text_font: "FiraSans-Bold.ttf".to_string(),
+                                    text_size: 24.,
+                                    text_color: Color::WHITE.with_alpha(0.75).into(),
+                                },
+                                SplashTextSection {
+                                    text: "Sergio Ribera\n".into(),
+                                    text_font: "FiraSans-Bold.ttf".to_string(),
+                                    text_size: 32.,
+                                    text_color: Srgba::WHITE.into(),
+                                },
+                            ],
+                            text_alignment: JustifyText::Center,
+                        }),
                         tint: palettes::css::SEA_GREEN.into(),
                         width: Val::Percent(30.),
                         height: Val::Px(150.),
@@ -61,18 +53,17 @@ fn main() {
                 })
                 .add_screen(SplashScreen {
                     brands: vec![SplashItem {
-                        asset: SplashAssetType::SingleText(
-                            Text::from_sections([TextSection::new(
-                                "With Bevy Engine",
-                                TextStyle {
-                                    font_size: 32.,
-                                    color: Color::WHITE,
-                                    ..default()
-                                },
-                            )])
-                            .with_justify(JustifyText::Center),
-                            "FiraSans-Bold.ttf".to_string(),
-                        ),
+                        asset: SplashAssetType::SingleText(SplashText {
+                            sections: vec![
+                                SplashTextSection {
+                                    text: "With Bevy Engine".into(),
+                                    text_font: "FiraSans-Bold.ttf".to_string(),
+                                    text_size: 32.,
+                                    text_color: Color::WHITE.into(),
+                                }
+                            ],
+                            text_alignment: JustifyText::Center,
+                        }),
                         tint: Color::WHITE,
                         width: Val::Percent(30.),
                         height: Val::Px(150.),
@@ -86,18 +77,17 @@ fn main() {
                 })
                 .add_screen(SplashScreen {
                     brands: vec![SplashItem {
-                        asset: SplashAssetType::SingleText(
-                            Text::from_sections([TextSection::new(
-                                "With Love <3",
-                                TextStyle {
-                                    font_size: 32.,
-                                    color: Color::WHITE,
-                                    ..default()
-                                },
-                            )])
-                            .with_justify(JustifyText::Center),
-                            "FiraSans-Bold.ttf".to_string(),
-                        ),
+                        asset: SplashAssetType::SingleText(SplashText {
+                            sections: vec![
+                                SplashTextSection {
+                                    text: "With Love <3".into(),
+                                    text_font: "FiraSans-Bold.ttf".to_string(),
+                                    text_size: 32.,
+                                    text_color: Color::WHITE.into(),
+                                }
+                            ],
+                            text_alignment: JustifyText::Center,
+                        }),
                         tint: Srgba::RED.into(),
                         width: Val::Percent(30.),
                         height: Val::Px(150.),
@@ -106,7 +96,7 @@ fn main() {
                         is_static: false,
                     }],
                     wait_to_start: bevy_splash_screen::WaitScreenType::AfterEnd,
-                    background_color: BackgroundColor(Color::WHITE),
+                    background_color: BackgroundColor(Color::BLACK),
                     ..default()
                 }),
         )
@@ -115,5 +105,5 @@ fn main() {
 }
 
 fn create_scene(mut cmd: Commands) {
-    cmd.spawn(Camera2dBundle::default());
+    cmd.spawn(Camera2d::default());
 }

--- a/examples/screens.rs
+++ b/examples/screens.rs
@@ -1,6 +1,8 @@
 use bevy::color::palettes;
 use bevy::prelude::*;
-use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashText, SplashTextSection};
+use bevy_splash_screen::{
+    SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashText, SplashTextSection,
+};
 use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Default, States, Hash, PartialEq, Eq)]
@@ -54,14 +56,12 @@ fn main() {
                 .add_screen(SplashScreen {
                     brands: vec![SplashItem {
                         asset: SplashAssetType::SingleText(SplashText {
-                            sections: vec![
-                                SplashTextSection {
-                                    text: "With Bevy Engine".into(),
-                                    text_font: "FiraSans-Bold.ttf".to_string(),
-                                    text_size: 32.,
-                                    text_color: Color::WHITE.into(),
-                                }
-                            ],
+                            sections: vec![SplashTextSection {
+                                text: "With Bevy Engine".into(),
+                                text_font: "FiraSans-Bold.ttf".to_string(),
+                                text_size: 32.,
+                                text_color: Color::WHITE.into(),
+                            }],
                             text_alignment: JustifyText::Center,
                         }),
                         tint: Color::WHITE,
@@ -78,14 +78,12 @@ fn main() {
                 .add_screen(SplashScreen {
                     brands: vec![SplashItem {
                         asset: SplashAssetType::SingleText(SplashText {
-                            sections: vec![
-                                SplashTextSection {
-                                    text: "With Love <3".into(),
-                                    text_font: "FiraSans-Bold.ttf".to_string(),
-                                    text_size: 32.,
-                                    text_color: Color::WHITE.into(),
-                                }
-                            ],
+                            sections: vec![SplashTextSection {
+                                text: "With Love <3".into(),
+                                text_font: "FiraSans-Bold.ttf".to_string(),
+                                text_size: 32.,
+                                text_color: Color::WHITE.into(),
+                            }],
                             text_alignment: JustifyText::Center,
                         }),
                         tint: Srgba::RED.into(),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,8 +1,8 @@
-use std::time::Duration;
-
+use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen};
 use bevy_tweening::EaseFunction;
+use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Default, States, Hash, PartialEq, Eq)]
 enum ScreenStates {
@@ -35,7 +35,7 @@ fn main() {
                                         "by\n",
                                         TextStyle {
                                             font_size: 24.,
-                                            color: Color::WHITE.with_a(0.75),
+                                            color: Color::WHITE.with_alpha(0.75),
                                             ..default()
                                         },
                                     ),
@@ -43,7 +43,7 @@ fn main() {
                                         "Sergio Ribera",
                                         TextStyle {
                                             font_size: 32.,
-                                            color: Color::BLUE,
+                                            color: Srgba::BLUE.into(),
                                             ..default()
                                         },
                                     ),
@@ -51,7 +51,7 @@ fn main() {
                                 .with_justify(JustifyText::Center),
                                 "FiraSans-Bold.ttf".to_string(),
                             ),
-                            tint: Color::SEA_GREEN,
+                            tint: palettes::css::SEA_GREEN.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
                             ease_function: EaseFunction::QuarticInOut.into(),
@@ -73,7 +73,7 @@ fn main() {
                 }),
         )
         .add_systems(Startup, create_scene)
-        .run()
+        .run();
 }
 
 fn create_scene(mut cmd: Commands) {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,7 @@
 use bevy::color::palettes;
 use bevy::prelude::*;
-use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen};
-use bevy_tweening::EaseFunction;
+use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashText, SplashTextSection};
+use bevy_math::curve::easing::EaseFunction;
 use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Default, States, Hash, PartialEq, Eq)]
@@ -21,40 +21,34 @@ fn main() {
                 .add_screen(SplashScreen {
                     brands: vec![
                         SplashItem {
-                            asset: SplashAssetType::SingleText(
-                                Text::from_sections([
-                                    TextSection::new(
-                                        "Simple Test\n",
-                                        TextStyle {
-                                            font_size: 40.,
-                                            color: Color::WHITE,
-                                            ..default()
-                                        },
-                                    ),
-                                    TextSection::new(
-                                        "by\n",
-                                        TextStyle {
-                                            font_size: 24.,
-                                            color: Color::WHITE.with_alpha(0.75),
-                                            ..default()
-                                        },
-                                    ),
-                                    TextSection::new(
-                                        "Sergio Ribera",
-                                        TextStyle {
-                                            font_size: 32.,
-                                            color: Srgba::BLUE.into(),
-                                            ..default()
-                                        },
-                                    ),
-                                ])
-                                .with_justify(JustifyText::Center),
-                                "FiraSans-Bold.ttf".to_string(),
+                            asset: SplashAssetType::SingleText(SplashText {
+                                sections: vec![
+                                    SplashTextSection {
+                                        text: "Simple Test\n".into(),
+                                        text_font: "FiraSans-Bold.ttf".to_string(),
+                                        text_size: 40.,
+                                        text_color: Color::WHITE.into(),
+                                    },
+                                   SplashTextSection {
+                                       text: "by\n".into(),
+                                       text_font: "FiraSans-Bold.ttf".to_string(),
+                                       text_size: 24.,
+                                       text_color: Color::WHITE.with_alpha(0.75).into(),
+                                   },
+                                   SplashTextSection {
+                                       text: "Sergio Ribera\n".into(),
+                                       text_font: "FiraSans-Bold.ttf".to_string(),
+                                       text_size: 32.,
+                                       text_color: Srgba::BLUE.into(),
+                                   },
+                               ],
+                                text_alignment: JustifyText::Center,
+                            }
                             ),
                             tint: palettes::css::SEA_GREEN.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),
-                            ease_function: EaseFunction::QuarticInOut.into(),
+                            ease_function: EaseFunction::QuinticInOut.into(),
                             duration: Duration::from_secs_f32(5.),
                             is_static: false,
                         },
@@ -77,5 +71,5 @@ fn main() {
 }
 
 fn create_scene(mut cmd: Commands) {
-    cmd.spawn(Camera2dBundle::default());
+    cmd.spawn(Camera2d::default());
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,9 @@
 use bevy::color::palettes;
 use bevy::prelude::*;
-use bevy_splash_screen::{SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashText, SplashTextSection};
 use bevy_math::curve::easing::EaseFunction;
+use bevy_splash_screen::{
+    SplashAssetType, SplashItem, SplashPlugin, SplashScreen, SplashText, SplashTextSection,
+};
 use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Default, States, Hash, PartialEq, Eq)]
@@ -29,22 +31,21 @@ fn main() {
                                         text_size: 40.,
                                         text_color: Color::WHITE.into(),
                                     },
-                                   SplashTextSection {
-                                       text: "by\n".into(),
-                                       text_font: "FiraSans-Bold.ttf".to_string(),
-                                       text_size: 24.,
-                                       text_color: Color::WHITE.with_alpha(0.75).into(),
-                                   },
-                                   SplashTextSection {
-                                       text: "Sergio Ribera\n".into(),
-                                       text_font: "FiraSans-Bold.ttf".to_string(),
-                                       text_size: 32.,
-                                       text_color: Srgba::BLUE.into(),
-                                   },
-                               ],
+                                    SplashTextSection {
+                                        text: "by\n".into(),
+                                        text_font: "FiraSans-Bold.ttf".to_string(),
+                                        text_size: 24.,
+                                        text_color: Color::WHITE.with_alpha(0.75).into(),
+                                    },
+                                    SplashTextSection {
+                                        text: "Sergio Ribera\n".into(),
+                                        text_font: "FiraSans-Bold.ttf".to_string(),
+                                        text_size: 32.,
+                                        text_color: Srgba::BLUE.into(),
+                                    },
+                                ],
                                 text_alignment: JustifyText::Center,
-                            }
-                            ),
+                            }),
                             tint: palettes::css::SEA_GREEN.into(),
                             width: Val::Percent(30.),
                             height: Val::Px(150.),

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use bevy_tweening::lens::*;
+use bevy_tweening::Targetable;
 
 pub trait InstanceLens {
     fn create(start: Color, end: Color) -> Self;
@@ -27,14 +28,14 @@ impl SplashTextColorLens {
 }
 
 impl Lens<Text> for SplashTextColorLens {
-    fn lerp(&mut self, target: &mut Text, ratio: f32) {
+    fn lerp(&mut self, target: &mut dyn Targetable<Text>, ratio: f32) {
         target
             .sections
             .iter_mut()
             .enumerate()
             .for_each(|(i, section)| {
                 use crate::ColorLerper as _;
-                let value = self.0[i].with_a(0.).lerp(&self.0[i], ratio);
+                let value = self.0[i].with_alpha(0.).lerp(&self.0[i], ratio);
                 section.style.color = value;
             });
     }
@@ -46,10 +47,10 @@ impl InstanceLens for SplashImageColorLens {
     }
 }
 
-impl Lens<BackgroundColor> for SplashImageColorLens {
-    fn lerp(&mut self, target: &mut BackgroundColor, ratio: f32) {
+impl Lens<UiImage> for SplashImageColorLens {
+    fn lerp(&mut self, target: &mut dyn Targetable<UiImage>, ratio: f32) {
         use crate::ColorLerper as _;
         let value = self.start.lerp(&self.end, ratio);
-        target.0 = value;
+        target.color = value;
     }
 }

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -29,7 +29,6 @@ impl SplashTextColorLens {
 
 impl Lens<TextColor> for SplashTextColorLens {
     fn lerp(&mut self, target: &mut dyn Targetable<TextColor>, ratio: f32) {
-
         use crate::ColorLerper as _;
         let value = self.0.with_alpha(0.).lerp(&self.0, ratio);
         target.0 = value;

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -15,29 +15,24 @@ pub struct SplashImageColorLens {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-/// Lens for interpolating Bevy Text sections. The single parameter is a reference to the color of each section.
-pub struct SplashTextColorLens(Vec<Color>);
+/// Lens for interpolating Bevy Text sections. The single parameter is a reference to the color of the individual text section.
+pub struct SplashTextColorLens(Color);
 
 impl SplashTextColorLens {
     /// Create instance of Text Lens
     ///
     /// * `colors`: Each color refers to a section and is placed in order.
-    pub fn new(colors: Vec<Color>) -> Self {
-        Self(colors)
+    pub fn new(color: Color) -> Self {
+        Self(color)
     }
 }
 
-impl Lens<Text> for SplashTextColorLens {
-    fn lerp(&mut self, target: &mut dyn Targetable<Text>, ratio: f32) {
-        target
-            .sections
-            .iter_mut()
-            .enumerate()
-            .for_each(|(i, section)| {
-                use crate::ColorLerper as _;
-                let value = self.0[i].with_alpha(0.).lerp(&self.0[i], ratio);
-                section.style.color = value;
-            });
+impl Lens<TextColor> for SplashTextColorLens {
+    fn lerp(&mut self, target: &mut dyn Targetable<TextColor>, ratio: f32) {
+
+        use crate::ColorLerper as _;
+        let value = self.0.with_alpha(0.).lerp(&self.0, ratio);
+        target.0 = value;
     }
 }
 
@@ -47,8 +42,8 @@ impl InstanceLens for SplashImageColorLens {
     }
 }
 
-impl Lens<UiImage> for SplashImageColorLens {
-    fn lerp(&mut self, target: &mut dyn Targetable<UiImage>, ratio: f32) {
+impl Lens<ImageNode> for SplashImageColorLens {
+    fn lerp(&mut self, target: &mut dyn Targetable<ImageNode>, ratio: f32) {
         use crate::ColorLerper as _;
         let value = self.start.lerp(&self.end, ratio);
         target.color = value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,24 @@ use splash::create_splash;
 pub use systems::ClearSplash;
 use systems::*;
 
+#[derive(Clone)]
+pub struct SplashText {
+    pub sections: Vec<SplashTextSection>,
+    pub text_alignment: JustifyText,
+}
+
+#[derive(Clone)]
+pub struct SplashTextSection {
+    pub text: Text2d,
+    pub text_font: String,
+    pub text_size: f32,
+    pub text_color: TextColor,
+}
+
 #[derive(Clone, Component)]
 pub enum SplashAssetType {
     /// Content and Font
-    SingleText(Text, String),
+    SingleText(SplashText),
     SingleImage(String),
 }
 
@@ -125,7 +139,7 @@ where
             .add_systems(
                 Update,
                 (
-                    component_animator_system::<UiImage>.run_if(in_state(self.state.clone())),
+                    component_animator_system::<ImageNode>.run_if(in_state(self.state.clone())),
                     update_splash::<S>.run_if(in_state(self.state.clone())),
                     splash_skip::<S>,
                 ),

--- a/src/splash.rs
+++ b/src/splash.rs
@@ -118,7 +118,7 @@ pub(crate) fn create_splash(
                                     SplashTextColorLens::new(
                                         text.sections
                                             .iter()
-                                            .map(|_| Color::WHITE.with_a(0.))
+                                            .map(|_| Color::WHITE.with_alpha(0.))
                                             .collect(),
                                     ),
                                 )
@@ -148,6 +148,7 @@ pub(crate) fn create_splash(
                                 texture: assets.load(handler),
                                 flip_x: false,
                                 flip_y: false,
+                                ..default()
                             },
                             style: Style {
                                 width: brand.width,
@@ -156,7 +157,7 @@ pub(crate) fn create_splash(
                             },
                             ..default()
                         },
-                        create_animator::<BackgroundColor, SplashImageColorLens>(
+                        create_animator::<UiImage, SplashImageColorLens>(
                             brand,
                             max_duration,
                             i_screen,
@@ -181,14 +182,14 @@ where
         Tween::new(
             brand.ease_function,
             Duration::from_secs(1),
-            L::create(brand.tint.with_a(0.), brand.tint.with_a(0.)),
+            L::create(brand.tint.with_alpha(0.), brand.tint.with_alpha(0.)),
         )
         .then(
             Delay::new(max_duration).then(
                 Tween::new(
                     brand.ease_function,
                     brand.duration,
-                    L::create(brand.tint.with_a(0.), brand.tint),
+                    L::create(brand.tint.with_alpha(0.), brand.tint),
                 )
                 .with_repeat_strategy(RepeatStrategy::MirroredRepeat)
                 .with_repeat_count(RepeatCount::Finite(2))

--- a/src/splash.rs
+++ b/src/splash.rs
@@ -11,7 +11,7 @@ fn get_max_duration(screens: SplashScreens, curr_screen: usize) -> Duration {
     }
     let next_screen = screens.0.get(curr_screen - 1).unwrap();
 
-    return match next_screen.wait_to_start {
+    match next_screen.wait_to_start {
         WaitScreenType::AfterEnd => Duration::from_secs(
             next_screen
                 .brands
@@ -24,7 +24,7 @@ fn get_max_duration(screens: SplashScreens, curr_screen: usize) -> Duration {
                 + 1,
         ),
         WaitScreenType::Specific(t) => t,
-    };
+    }
 }
 
 fn create_text_color_animator(brand: &SplashItem, text_section: &SplashTextSection, i_screen: usize, max_duration: Duration) -> Animator<TextColor> {
@@ -115,7 +115,7 @@ pub(crate) fn create_splash(
                                     font_size: first_section.text_size,
                                     ..default()
                                 },
-                                first_section.text_color.clone(),
+                                first_section.text_color,
                                 Node {
                                     flex_direction,
                                     flex_wrap,
@@ -139,7 +139,7 @@ pub(crate) fn create_splash(
                                             font_size: section.text_size,
                                             ..default()
                                         },
-                                        section.text_color.clone(),
+                                        section.text_color,
                                         Node {
                                             flex_direction,
                                             flex_wrap,

--- a/src/splash.rs
+++ b/src/splash.rs
@@ -3,11 +3,7 @@ use std::time::Duration;
 use bevy::prelude::*;
 use bevy_tweening::*;
 
-use crate::{
-    systems::{ClearSplash, SplashBackground},
-    InstanceLens, SplashAssetType, SplashImageColorLens, SplashItem, SplashScreens,
-    SplashTextColorLens, SplashType, WaitScreenType,
-};
+use crate::{systems::{ClearSplash, SplashBackground}, InstanceLens, SplashAssetType, SplashImageColorLens, SplashItem, SplashScreens, SplashTextColorLens, SplashType, WaitScreenType, SplashTextSection};
 
 fn get_max_duration(screens: SplashScreens, curr_screen: usize) -> Duration {
     if curr_screen == 0 {
@@ -31,14 +27,39 @@ fn get_max_duration(screens: SplashScreens, curr_screen: usize) -> Duration {
     };
 }
 
+fn create_text_color_animator(brand: &SplashItem, text_section: &SplashTextSection, i_screen: usize, max_duration: Duration) -> Animator<TextColor> {
+    Animator::new(
+        Tween::new(
+            brand.ease_function,
+            Duration::from_secs(1),
+            SplashTextColorLens::new(
+                text_section.text_color.0.with_alpha(0.),
+            ),
+        )
+            .then(
+                Delay::new(max_duration).then(
+                    Tween::new(
+                        brand.ease_function,
+                        brand.duration,
+                        SplashTextColorLens::new(
+                            text_section.text_color.0.with_alpha(1.),
+                        ),
+                    )
+                        .with_repeat_strategy(RepeatStrategy::MirroredRepeat)
+                        .with_repeat_count(RepeatCount::Finite(2))
+                        .with_completed_event(i_screen as u64),
+                ),
+            ),
+    )
+}
+
 pub(crate) fn create_splash(
     mut cmd: Commands,
     assets: Res<AssetServer>,
     screens: Res<SplashScreens>,
 ) {
     // Background
-    cmd.spawn(NodeBundle {
-        style: Style {
+    cmd.spawn((Node {
             display: Display::Flex,
             position_type: PositionType::Absolute,
             width: Val::Percent(100.),
@@ -46,9 +67,8 @@ pub(crate) fn create_splash(
             overflow: Overflow::clip(),
             ..default()
         },
-        background_color: BackgroundColor(screens.0[0].background_color.0),
-        ..default()
-    })
+        BackgroundColor(screens.0[0].background_color.0)
+    ))
     .insert(ClearSplash)
     .insert(SplashBackground {
         screens: screens
@@ -69,13 +89,11 @@ pub(crate) fn create_splash(
 
         // Parent of screen content
         // Contains brands
-        cmd.spawn(NodeBundle {
-            style: Style {
+        cmd.spawn(Node {
                 flex_wrap,
                 flex_direction,
                 display: Display::Flex,
                 position_type: PositionType::Absolute,
-                direction: Direction::LeftToRight,
                 align_items: AlignItems::Center,
                 align_content: AlignContent::Center,
                 justify_content: JustifyContent::Center,
@@ -83,87 +101,79 @@ pub(crate) fn create_splash(
                 height: Val::Percent(100.),
                 overflow: Overflow::clip(),
                 ..default()
-            },
-            ..default()
         })
         .insert(ClearSplash)
         .with_children(|cmd| {
             for brand in screen.brands.iter() {
                 match &brand.asset {
-                    SplashAssetType::SingleText(text, font) => {
-                        let text = Text::from_sections(text.sections.iter().map(|s| TextSection {
-                            value: s.value.clone(),
-                            style: TextStyle {
-                                font: assets.load(font),
-                                ..s.style
-                            },
-                        }))
-                        .with_justify(text.justify);
-                        cmd.spawn((
-                            TextBundle {
-                                text: text.clone(),
-                                style: Style {
+                    SplashAssetType::SingleText(splash_text) => {
+                        if let Some((first_section, remaining_sections)) = splash_text.sections.split_last() {
+                            let mut parent_text = cmd.spawn((
+                                first_section.text.clone(),
+                                TextFont {
+                                    font: assets.load(first_section.text_font.clone()),
+                                    font_size: first_section.text_size,
+                                    ..default()
+                                },
+                                first_section.text_color.clone(),
+                                Node {
                                     flex_direction,
                                     flex_wrap,
                                     width: brand.width,
                                     height: brand.height,
                                     ..default()
                                 },
-                                ..default()
-                            },
-                            Animator::new(
-                                Tween::new(
-                                    brand.ease_function,
-                                    Duration::from_secs(1),
-                                    SplashTextColorLens::new(
-                                        text.sections
-                                            .iter()
-                                            .map(|_| Color::WHITE.with_alpha(0.))
-                                            .collect(),
-                                    ),
-                                )
-                                .then(
-                                    Delay::new(max_duration).then(
-                                        Tween::new(
-                                            brand.ease_function,
-                                            brand.duration,
-                                            SplashTextColorLens::new(
-                                                text.sections
-                                                    .iter()
-                                                    .map(|s| s.style.color)
-                                                    .collect(),
-                                            ),
-                                        )
-                                        .with_repeat_strategy(RepeatStrategy::MirroredRepeat)
-                                        .with_repeat_count(RepeatCount::Finite(2))
-                                        .with_completed_event(i_screen as u64),
-                                    ),
-                                ),
-                            ),
-                        ))
+                                TextLayout {
+                                    justify: splash_text.text_alignment,
+                                    ..default()
+                                },
+                                create_text_color_animator(brand, first_section, i_screen, max_duration),
+                            ));
+
+                            for section in remaining_sections.iter().rev() {
+                                parent_text.with_children(|cmd| {
+                                    cmd.spawn((
+                                        TextSpan(section.text.to_string()),
+                                        TextFont {
+                                            font: assets.load(section.text_font.clone()),
+                                            font_size: section.text_size,
+                                            ..default()
+                                        },
+                                        section.text_color.clone(),
+                                        Node {
+                                            flex_direction,
+                                            flex_wrap,
+                                            width: brand.width,
+                                            height: brand.height,
+                                            ..default()
+                                        },
+                                        create_text_color_animator(brand, section, i_screen, max_duration),
+                                    ));
+                                });
+                            }
+                        }
                     }
-                    SplashAssetType::SingleImage(handler) => cmd.spawn((
-                        ImageBundle {
-                            image: UiImage {
-                                texture: assets.load(handler),
+                    SplashAssetType::SingleImage(handler) => {
+                        cmd.spawn((
+                            ImageNode {
+                                image: assets.load(handler),
                                 flip_x: false,
                                 flip_y: false,
                                 ..default()
                             },
-                            style: Style {
+                            Node {
                                 width: brand.width,
                                 height: brand.height,
                                 ..default()
                             },
-                            ..default()
-                        },
-                        create_animator::<UiImage, SplashImageColorLens>(
-                            brand,
-                            max_duration,
-                            i_screen,
-                        ),
-                    )),
-                };
+                            create_animator::<ImageNode, SplashImageColorLens>(
+                                brand,
+                                max_duration,
+                                i_screen,
+                            ),
+                        ));
+                    }
+                }
             }
         });
     }

--- a/src/splash.rs
+++ b/src/splash.rs
@@ -3,7 +3,11 @@ use std::time::Duration;
 use bevy::prelude::*;
 use bevy_tweening::*;
 
-use crate::{systems::{ClearSplash, SplashBackground}, InstanceLens, SplashAssetType, SplashImageColorLens, SplashItem, SplashScreens, SplashTextColorLens, SplashType, WaitScreenType, SplashTextSection};
+use crate::{
+    systems::{ClearSplash, SplashBackground},
+    InstanceLens, SplashAssetType, SplashImageColorLens, SplashItem, SplashScreens,
+    SplashTextColorLens, SplashTextSection, SplashType, WaitScreenType,
+};
 
 fn get_max_duration(screens: SplashScreens, curr_screen: usize) -> Duration {
     if curr_screen == 0 {
@@ -27,29 +31,30 @@ fn get_max_duration(screens: SplashScreens, curr_screen: usize) -> Duration {
     }
 }
 
-fn create_text_color_animator(brand: &SplashItem, text_section: &SplashTextSection, i_screen: usize, max_duration: Duration) -> Animator<TextColor> {
+fn create_text_color_animator(
+    brand: &SplashItem,
+    text_section: &SplashTextSection,
+    i_screen: usize,
+    max_duration: Duration,
+) -> Animator<TextColor> {
     Animator::new(
         Tween::new(
             brand.ease_function,
             Duration::from_secs(1),
-            SplashTextColorLens::new(
-                text_section.text_color.0.with_alpha(0.),
-            ),
+            SplashTextColorLens::new(text_section.text_color.0.with_alpha(0.)),
         )
-            .then(
-                Delay::new(max_duration).then(
-                    Tween::new(
-                        brand.ease_function,
-                        brand.duration,
-                        SplashTextColorLens::new(
-                            text_section.text_color.0.with_alpha(1.),
-                        ),
-                    )
-                        .with_repeat_strategy(RepeatStrategy::MirroredRepeat)
-                        .with_repeat_count(RepeatCount::Finite(2))
-                        .with_completed_event(i_screen as u64),
-                ),
+        .then(
+            Delay::new(max_duration).then(
+                Tween::new(
+                    brand.ease_function,
+                    brand.duration,
+                    SplashTextColorLens::new(text_section.text_color.0.with_alpha(1.)),
+                )
+                .with_repeat_strategy(RepeatStrategy::MirroredRepeat)
+                .with_repeat_count(RepeatCount::Finite(2))
+                .with_completed_event(i_screen as u64),
             ),
+        ),
     )
 }
 
@@ -59,7 +64,8 @@ pub(crate) fn create_splash(
     screens: Res<SplashScreens>,
 ) {
     // Background
-    cmd.spawn((Node {
+    cmd.spawn((
+        Node {
             display: Display::Flex,
             position_type: PositionType::Absolute,
             width: Val::Percent(100.),
@@ -67,7 +73,7 @@ pub(crate) fn create_splash(
             overflow: Overflow::clip(),
             ..default()
         },
-        BackgroundColor(screens.0[0].background_color.0)
+        BackgroundColor(screens.0[0].background_color.0),
     ))
     .insert(ClearSplash)
     .insert(SplashBackground {
@@ -90,24 +96,26 @@ pub(crate) fn create_splash(
         // Parent of screen content
         // Contains brands
         cmd.spawn(Node {
-                flex_wrap,
-                flex_direction,
-                display: Display::Flex,
-                position_type: PositionType::Absolute,
-                align_items: AlignItems::Center,
-                align_content: AlignContent::Center,
-                justify_content: JustifyContent::Center,
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
-                overflow: Overflow::clip(),
-                ..default()
+            flex_wrap,
+            flex_direction,
+            display: Display::Flex,
+            position_type: PositionType::Absolute,
+            align_items: AlignItems::Center,
+            align_content: AlignContent::Center,
+            justify_content: JustifyContent::Center,
+            width: Val::Percent(100.),
+            height: Val::Percent(100.),
+            overflow: Overflow::clip(),
+            ..default()
         })
         .insert(ClearSplash)
         .with_children(|cmd| {
             for brand in screen.brands.iter() {
                 match &brand.asset {
                     SplashAssetType::SingleText(splash_text) => {
-                        if let Some((first_section, remaining_sections)) = splash_text.sections.split_last() {
+                        if let Some((first_section, remaining_sections)) =
+                            splash_text.sections.split_last()
+                        {
                             let mut parent_text = cmd.spawn((
                                 first_section.text.clone(),
                                 TextFont {
@@ -127,7 +135,12 @@ pub(crate) fn create_splash(
                                     justify: splash_text.text_alignment,
                                     ..default()
                                 },
-                                create_text_color_animator(brand, first_section, i_screen, max_duration),
+                                create_text_color_animator(
+                                    brand,
+                                    first_section,
+                                    i_screen,
+                                    max_duration,
+                                ),
                             ));
 
                             for section in remaining_sections.iter().rev() {
@@ -147,7 +160,12 @@ pub(crate) fn create_splash(
                                             height: brand.height,
                                             ..default()
                                         },
-                                        create_text_color_animator(brand, section, i_screen, max_duration),
+                                        create_text_color_animator(
+                                            brand,
+                                            section,
+                                            i_screen,
+                                            max_duration,
+                                        ),
                                     ));
                                 });
                             }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use bevy::{
     input::{gamepad::GamepadEvent, keyboard::KeyboardInput, mouse::MouseButtonInput},
     prelude::*,
+    state::state::{FreelyMutableState, NextState, States},
 };
 use bevy_tweening::TweenCompleted;
 
@@ -25,7 +26,7 @@ pub(crate) struct SplashBackground {
 //
 // Remove all nodes when splash end
 //
-pub(crate) fn splash_end<'a, S: States>(
+pub(crate) fn splash_end<'a, S: FreelyMutableState>(
     mut cmd: Commands,
     next_state: S,
     brands: impl Iterator<Item = (Entity, &'a Node, &'a ClearSplash)>,
@@ -33,13 +34,13 @@ pub(crate) fn splash_end<'a, S: States>(
     for (entity, _, _) in brands {
         cmd.entity(entity).despawn_recursive();
     }
-    cmd.insert_resource(NextState(Some(next_state)));
+    cmd.insert_resource(NextState::Pending(next_state));
 }
 
 //
 // Logic to end splash and change background color
 //
-pub(crate) fn update_splash<S: States>(
+pub(crate) fn update_splash<S: FreelyMutableState>(
     cmd: Commands,
     brands: Query<(Entity, &Node, &ClearSplash)>,
     mut background: Query<(&Node, &mut BackgroundColor, &SplashBackground)>,
@@ -78,7 +79,7 @@ pub(crate) fn update_splash<S: States>(
 //
 // System for skip splash
 //
-pub(crate) fn splash_skip<S: States>(
+pub(crate) fn splash_skip<S: FreelyMutableState>(
     cmd: Commands,
     mut kbd: EventReader<KeyboardInput>,
     mut mouse: EventReader<MouseButtonInput>,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -32,7 +32,7 @@ pub(crate) fn splash_end<'a, S: FreelyMutableState>(
     brands: Query<(Entity, &Node, &ClearSplash)>,
 ) {
     for (entity, _, _) in brands.iter() {
-        cmd.entity(entity).despawn_recursive();
+        cmd.entity(entity).despawn();
     }
     cmd.insert_resource(NextState::Pending(next_state));
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -29,9 +29,9 @@ pub(crate) struct SplashBackground {
 pub(crate) fn splash_end<'a, S: FreelyMutableState>(
     mut cmd: Commands,
     next_state: S,
-    brands: impl Iterator<Item = (Entity, &'a Node, &'a ClearSplash)>,
+    brands: Query<(Entity, &Node, &ClearSplash)>,
 ) {
-    for (entity, _, _) in brands {
+    for (entity, _, _) in brands.iter() {
         cmd.entity(entity).despawn_recursive();
     }
     cmd.insert_resource(NextState::Pending(next_state));
@@ -72,7 +72,7 @@ pub(crate) fn update_splash<S: FreelyMutableState>(
         }
     }
     if clear {
-        splash_end(cmd, max_screens.1.clone(), brands.iter());
+        splash_end(cmd, max_screens.1.clone(), brands);
     }
 }
 
@@ -111,6 +111,6 @@ pub(crate) fn splash_skip<S: FreelyMutableState>(
     }
 
     if done || !dev_skip.is_empty() {
-        splash_end(cmd, max_screens.1.clone(), brands.iter());
+        splash_end(cmd, max_screens.1.clone(), brands);
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -26,7 +26,7 @@ pub(crate) struct SplashBackground {
 //
 // Remove all nodes when splash end
 //
-pub(crate) fn splash_end<'a, S: FreelyMutableState>(
+pub(crate) fn splash_end<S: FreelyMutableState>(
     mut cmd: Commands,
     next_state: S,
     brands: Query<(Entity, &Node, &ClearSplash)>,


### PR DESCRIPTION
Depends on this bevy_tweening bevy update, dependency needs to be updated to be from your repository then:
https://github.com/SergioRibera/bevy_tweening/pull/3

Examples work except for the skippable one, that one is broken with a black screen, not sure why :/

Updated the version table in the readme.md. However I don't have permissions to add labels/update crate.io, so that would need to be done from your side.